### PR TITLE
fix systemctl sequense to enable consul.service when it's already ena…

### DIFF
--- a/ambari-server/src/main/python/bootstrap.py
+++ b/ambari-server/src/main/python/bootstrap.py
@@ -888,7 +888,8 @@ class BootstrapDefault(Bootstrap):
                   params.bootdir, self.host_log)
         retcode10 = ssh.run()
 
-        command = "sudo systemctl enable consul.service && " \
+        command = "sudo systemctl disable consul.service && " \
+                  "sudo systemctl enable consul.service && " \
                   "sudo rm -fR /var/lib/consul/* && " \
                   "sudo systemctl restart consul.service && " \
                   "sudo systemctl restart dnsmasq.service"


### PR DESCRIPTION
…bled

in case of having error:

```
==========================

Command start time 2016-02-24 13:32:28
Failed to execute operation: File exists

Connection to 10.1.44.129 closed.
SSH command execution finished
host=10.1.44.129, exitcode=1
Command end time 2016-02-24 13:32:38
Failed to execute operation: File exists

Connection to 10.1.44.129 closed.

ERROR: Bootstrap of host 10.1.44.129 fails because previous action finished with non-zero exit code (1)
ERROR MESSAGE: Execute of '<bound method BootstrapDefault.deployConsul of <BootstrapDefault(Thread-3, started daemon 140509965936384)>>' failed
STDOUT: Try to execute '<bound method BootstrapDefault.deployConsul of <BootstrapDefault(Thread-3, started daemon 140509965936384)>>'

```
